### PR TITLE
Studio 14367

### DIFF
--- a/api_example/.mvn/extensions.xml
+++ b/api_example/.mvn/extensions.xml
@@ -3,6 +3,6 @@
     <extension>
          <groupId>org.mule.maven.exchange</groupId>
          <artifactId>polyglot-exchange</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2-SNAPSHOT</version>
     </extension>
 </extensions>

--- a/api_example/exchange.json
+++ b/api_example/exchange.json
@@ -7,12 +7,12 @@
         {
             "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
             "assetId": "training-american-flight-data-type",
-            "version": "1.0.1"
+            "version": "1.0.2-SNAPSHOT"
         },
         {
             "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
             "assetId": "training-american-flights-example",
-            "version": "1.0.1"
+            "version": "1.0.2-SNAPSHOT"
         }
     ],
     "groupId": "e391ca1a-41ef-49a4-88b3-ae1106af1867",

--- a/exchange-model/pom.xml
+++ b/exchange-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>exchange_maven_client</artifactId>
         <groupId>org.mule.maven.exchange</groupId>
-        <version>1.0.1</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/exchange_api_packager/pom.xml
+++ b/exchange_api_packager/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>exchange_maven_client</artifactId>
         <groupId>org.mule.maven.exchange</groupId>
-        <version>1.0.1</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/exchange_api_packager/src/main/java/org/mule/maven/exchange/FullApiGeneratorMojo.java
+++ b/exchange_api_packager/src/main/java/org/mule/maven/exchange/FullApiGeneratorMojo.java
@@ -1,6 +1,7 @@
 package org.mule.maven.exchange;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
@@ -13,6 +14,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -60,8 +62,9 @@ public class FullApiGeneratorMojo extends AbstractMojo {
         final File buildDirectory = new File(project.getBuild().getDirectory());
         final File fullApiDirectory = getFatApiDirectory(buildDirectory);
         final File sourceDirectory = new File(project.getBuild().getSourceDirectory());
+        final String targetRootPath = fullApiDirectory.getPath() + File.separator + EXCHANGE_MODULES;
         try {
-            unzipDependenciesAndCopyTo(new File(buildDirectory, MAVEN_SKIP_REST_CONNECT), new File(fullApiDirectory, EXCHANGE_MODULES));
+            unzipDependenciesAndCopyTo(new File(buildDirectory, MAVEN_SKIP_REST_CONNECT), new File(fullApiDirectory, EXCHANGE_MODULES), targetRootPath);
             FileUtils.copyDirectory(sourceDirectory, fullApiDirectory, new ApiSourceFileFilter(sourceDirectory, buildDirectory), true);
         } catch (IOException e) {
             throw new MojoExecutionException("Exception while trying to copy sources for `exchange-generate-full-api`", e);
@@ -69,17 +72,45 @@ public class FullApiGeneratorMojo extends AbstractMojo {
 
     }
 
-    private void unzipDependenciesAndCopyTo(File sourceFile, File targetFile) throws MojoExecutionException {
+    private void unzipDependenciesAndCopyTo(File sourceFile, File targetFile, String targetRootPath) throws MojoExecutionException {
         try {
             if (sourceFile.isDirectory()) {
                 File[] listFiles = sourceFile.listFiles();
                 if (listFiles != null) {
                     for (File childFile : listFiles) {
-                        unzipDependenciesAndCopyTo(childFile, new File(targetFile, childFile.getName()));
+                        unzipDependenciesAndCopyTo(childFile, new File(targetFile, childFile.getName()), targetRootPath);
                     }
                 }
             } else if (sourceFile.isFile() && sourceFile.getName().endsWith(".zip")) {
-                File targetDirectory = targetFile.getParentFile();
+                // there are cases that the groupId is generated folder levels, we need to reduce the amount of folders
+                // to one and build the groupId with dot instead of slash
+
+                // assuming that the path is built with groupId/artifactId/version/ramlFileName.zip
+                int validFolders = 4;
+                File finalTargetFile = targetFile;
+                File currentDirectory = targetFile;
+                boolean wellBuilded = false;
+                while(validFolders > 0){
+                    if(currentDirectory.getParentFile().getPath().equals(targetRootPath)){
+                        // the path is well built as we found the groupId represented with one folder level
+                        wellBuilded = true;
+                    } else if(validFolders > 1){
+                        currentDirectory = currentDirectory.getParentFile();
+                    }
+
+                    validFolders--;
+                }
+                if(!wellBuilded){
+                    String endPath = StringUtils.remove(targetFile.getPath(), currentDirectory.getPath());
+                    String groupId = StringUtils.remove(currentDirectory.getPath(), targetRootPath + File.separator);
+                    String newGroupId = StringUtils.replace(groupId, File.separator, ".");
+                    String finalPath = targetRootPath + File.separator + newGroupId + endPath;
+
+                    finalTargetFile = new File(finalPath);
+                }
+
+
+                File targetDirectory = finalTargetFile.getParentFile();
                 targetDirectory.mkdirs();
                 byte[] buffer = new byte[1024];
                 try (ZipInputStream zis = new ZipInputStream(new FileInputStream(sourceFile))) {
@@ -87,10 +118,14 @@ public class FullApiGeneratorMojo extends AbstractMojo {
                     ZipEntry zipEntry = zis.getNextEntry();
                     while (zipEntry != null) {
                         File newFile = new File(targetDirectory, zipEntry.getName());
-                        try (FileOutputStream fos = new FileOutputStream(newFile)) {
-                            int len;
-                            while ((len = zis.read(buffer)) > 0) {
-                                fos.write(buffer, 0, len);
+                        if(zipEntry.isDirectory()){
+                            newFile.mkdir();
+                        }else{
+                            try (FileOutputStream fos = new FileOutputStream(newFile)) {
+                                int len;
+                                while ((len = zis.read(buffer)) > 0) {
+                                    fos.write(buffer, 0, len);
+                                }
                             }
                         }
                         zipEntry = zis.getNextEntry();

--- a/polyglot-exchange/pom.xml
+++ b/polyglot-exchange/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.mule.maven.exchange</groupId>
         <artifactId>exchange_maven_client</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
 
 

--- a/polyglot-exchange/src/main/java/org/mule/maven/exchange/ExchangeModelProcessor.java
+++ b/polyglot-exchange/src/main/java/org/mule/maven/exchange/ExchangeModelProcessor.java
@@ -45,7 +45,7 @@ public class ExchangeModelProcessor implements ModelProcessor {
     private static final String EXCHANGE_JSON = "exchange.json";
     private static final String TEMPORAL_EXCHANGE_XML = ".exchange.xml";
 
-    public static final String PACKAGER_VERSION = "1.0.1";
+    public static final String PACKAGER_VERSION = "1.0.2-SNAPSHOT";
 
     public static final String MAVEN_FACADE_SYSTEM_PROPERTY = "-Dexchange.maven.repository.url";
 

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/basic/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/basic/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>1.0.1</version>
+                <version>1.0.2-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/fragment/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/fragment/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>1.0.1</version>
+                <version>1.0.2-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/exchange.json
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/exchange.json
@@ -7,12 +7,12 @@
     {
       "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
       "assetId": "training-american-flight-data-type",
-      "version": "1.0.1"
+      "version": "1.0.2-SNAPSHOT"
     },
     {
       "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
       "assetId": "training-american-flights-example",
-      "version": "1.0.1"
+      "version": "1.0.2-SNAPSHOT"
     }
   ],
   "groupId": "e391ca1a-41ef-49a4-88b3-ae1106af1867",

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
@@ -10,14 +10,14 @@
         <dependency>
             <groupId>68ef9520-24e9-4cf2-b2f5-620025690913</groupId>
             <artifactId>training-american-flight-data-type</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2-SNAPSHOT</version>
             <type>zip</type>
             <classifier>raml-fragment</classifier>
         </dependency>
         <dependency>
             <groupId>68ef9520-24e9-4cf2-b2f5-620025690913</groupId>
             <artifactId>training-american-flights-example</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2-SNAPSHOT</version>
             <type>zip</type>
             <classifier>raml-fragment</classifier>
         </dependency>
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>1.0.1</version>
+                <version>1.0.2-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/groupId_from_apivcs/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/groupId_from_apivcs/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>1.0.1</version>
+                <version>1.0.2-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.mule.maven.exchange</groupId>
     <artifactId>exchange_maven_client</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
 
 
     <name>exchange_maven_client</name>


### PR DESCRIPTION
Currently there is some difference in the path manipulation between maven dependency plugin and AMF client. 
The issue happens when a groupId contains dots and the path that AMF expects is with dots but the maven dependency plugin is making sub folders instead of keeping the complete groupId as a unique folder.

Example:
Dependency:
`"dependencies" : [ {
    "groupId" : "com.mule",
    "assetId" : "americanflightdatatype",
    "version" : "1.0.1"
  }`

What maven does:
`.../com/mule/americanflightdatatype/1.0.1/americanflightdatatype-1.0.1-raml-fragment.zip`
AMF expects:
`.../com.mule/americanflightdatatype/1.0.1/americanflightdatatype-1.0.1-raml-fragment.zip`

Another issue was also fixed, regarding the unzip logic. When a dependency contains sub folders the unzip method does not contemplates it throwing an IO Exception.

Jiras:
https://www.mulesoft.org/jira/browse/STUDIO-14367
https://www.mulesoft.org/jira/browse/STUDIO-14483