### PR TITLE
Adding ExchangeResourceLoader to amf validation also advancing to 1.0…

### DIFF
--- a/api_example/.mvn/extensions.xml
+++ b/api_example/.mvn/extensions.xml
@@ -3,6 +3,6 @@
     <extension>
          <groupId>org.mule.maven.exchange</groupId>
          <artifactId>polyglot-exchange</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
     </extension>
 </extensions>

--- a/api_example/exchange.json
+++ b/api_example/exchange.json
@@ -7,12 +7,12 @@
         {
             "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
             "assetId": "training-american-flight-data-type",
-            "version": "1.0.2"
+            "version": "1.0.3-SNAPSHOT"
         },
         {
             "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
             "assetId": "training-american-flights-example",
-            "version": "1.0.2"
+            "version": "1.0.3-SNAPSHOT"
         }
     ],
     "groupId": "e391ca1a-41ef-49a4-88b3-ae1106af1867",

--- a/exchange-model/pom.xml
+++ b/exchange-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>exchange_maven_client</artifactId>
         <groupId>org.mule.maven.exchange</groupId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/exchange_api_packager/pom.xml
+++ b/exchange_api_packager/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>exchange_maven_client</artifactId>
         <groupId>org.mule.maven.exchange</groupId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/exchange_api_packager/src/main/java/org/mule/maven/exchange/ValidateApiMojo.java
+++ b/exchange_api_packager/src/main/java/org/mule/maven/exchange/ValidateApiMojo.java
@@ -11,6 +11,8 @@ import amf.client.parse.Oas20Parser;
 import amf.client.parse.Oas20YamlParser;
 import amf.client.parse.Raml08Parser;
 import amf.client.parse.RamlParser;
+import amf.client.remote.Content;
+import amf.client.resource.ClientResourceLoader;
 import amf.client.validate.ValidationReport;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.AbstractMojo;
@@ -19,12 +21,14 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.*;
 import org.apache.maven.project.MavenProject;
 import org.mule.maven.exchange.utils.ApiProjectConstants;
+import org.mule.maven.exchange.utils.ExchangeModulesResourceLoader;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 @Mojo(name = "validate-api", defaultPhase = LifecyclePhase.COMPILE, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
@@ -58,12 +62,14 @@ public class ValidateApiMojo extends AbstractMojo {
             try {
                 AMF.init().get();
 
-                final Environment env = DefaultEnvironment.apply();
+                Environment env = DefaultEnvironment.apply();
 
                 /* Parsing Raml 10 with specified file returning future. */
                 final BaseUnit result;
                 final ProfileName profileName;
-                final File ramlFile = new File(calculateFatDirectory(buildDirectory), this.mainFile);
+                File parent = calculateFatDirectory(buildDirectory);
+                env = env.addClientLoader(new ExchangeModulesResourceLoader(parent.getAbsolutePath().replace(File.separator,"/")));
+                final File ramlFile = new File(parent, this.mainFile);
                 if (!ramlFile.exists()) {
                     throw new MojoFailureException("The specified 'main' property '" + this.mainFile + "' can not be found. Please review your exchange.json");
                 }

--- a/exchange_api_packager/src/main/java/org/mule/maven/exchange/utils/ExchangeModulesResourceLoader.java
+++ b/exchange_api_packager/src/main/java/org/mule/maven/exchange/utils/ExchangeModulesResourceLoader.java
@@ -1,0 +1,55 @@
+package org.mule.maven.exchange.utils;
+
+import amf.client.remote.Content;
+import amf.client.resource.ClientResourceLoader;
+import amf.client.resource.ResourceNotFound;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ExchangeModulesResourceLoader implements ClientResourceLoader {
+
+    private static final String EXCHANGE_MODULES = "/exchange_modules/";
+
+    private static final String EXCHANGE_MODULES_REGEX = ".*(\\/exchange_modules\\/.*)";
+
+    private static final Pattern EXCHANGE_MODULES_PATTERN = Pattern.compile(EXCHANGE_MODULES_REGEX);
+
+
+    private final String rootProjectPath;
+
+    public ExchangeModulesResourceLoader(String rootProjectPath){
+        this.rootProjectPath = rootProjectPath;
+    }
+
+    @Override
+    public CompletableFuture<Content> fetch(String resource) {
+        Matcher matcher = EXCHANGE_MODULES_PATTERN.matcher(resource);
+        if (matcher.matches()){
+            String group = matcher.group(matcher.groupCount());
+            File file = new File(rootProjectPath, group);
+            try {
+                String stringContent = FileUtils.readFileToString(file);
+                return CompletableFuture.completedFuture(new Content(stringContent,resource));
+            } catch (IOException e) {
+                e.fillInStackTrace();
+            }
+        }
+        return failedFuture(resource);
+    }
+
+    private CompletableFuture<Content> failedFuture(String resource) {
+        return CompletableFuture.supplyAsync(() -> {
+            throw new RuntimeException(new ResourceNotFound(resource));
+        });
+    }
+
+    @Override
+    public boolean accepts(String resource) {
+        return resource.contains(EXCHANGE_MODULES);
+    }
+}

--- a/polyglot-exchange/pom.xml
+++ b/polyglot-exchange/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.mule.maven.exchange</groupId>
         <artifactId>exchange_maven_client</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
 

--- a/polyglot-exchange/src/main/java/org/mule/maven/exchange/ExchangeModelProcessor.java
+++ b/polyglot-exchange/src/main/java/org/mule/maven/exchange/ExchangeModelProcessor.java
@@ -45,7 +45,7 @@ public class ExchangeModelProcessor implements ModelProcessor {
     private static final String EXCHANGE_JSON = "exchange.json";
     private static final String TEMPORAL_EXCHANGE_XML = ".exchange.xml";
 
-    public static final String PACKAGER_VERSION = "1.0.2";
+    public static final String PACKAGER_VERSION = "1.0.3-SNAPSHOT";
 
     public static final String MAVEN_FACADE_SYSTEM_PROPERTY = "-Dexchange.maven.repository.url";
 

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/basic/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/basic/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>1.0.2</version>
+                <version>1.0.3-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/fragment/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/fragment/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>1.0.2</version>
+                <version>1.0.3-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/exchange.json
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/exchange.json
@@ -7,12 +7,12 @@
     {
       "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
       "assetId": "training-american-flight-data-type",
-      "version": "1.0.2"
+      "version": "1.0.3-SNAPSHOT"
     },
     {
       "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
       "assetId": "training-american-flights-example",
-      "version": "1.0.2"
+      "version": "1.0.3-SNAPSHOT"
     }
   ],
   "groupId": "e391ca1a-41ef-49a4-88b3-ae1106af1867",

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
@@ -10,14 +10,14 @@
         <dependency>
             <groupId>68ef9520-24e9-4cf2-b2f5-620025690913</groupId>
             <artifactId>training-american-flight-data-type</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.3-SNAPSHOT</version>
             <type>zip</type>
             <classifier>raml-fragment</classifier>
         </dependency>
         <dependency>
             <groupId>68ef9520-24e9-4cf2-b2f5-620025690913</groupId>
             <artifactId>training-american-flights-example</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.3-SNAPSHOT</version>
             <type>zip</type>
             <classifier>raml-fragment</classifier>
         </dependency>
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>1.0.2</version>
+                <version>1.0.3-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/groupId_from_apivcs/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/groupId_from_apivcs/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>1.0.2</version>
+                <version>1.0.3-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.mule.maven.exchange</groupId>
     <artifactId>exchange_maven_client</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.2</version>
+    <version>1.0.3-SNAPSHOT</version>
 
 
     <name>exchange_maven_client</name>


### PR DESCRIPTION
….3-SNAPSHOT

I added a new resourceloader to amf validation to support cases where there is a relative include written inside one of the transitive dependencies:
!include exchange_modules/g/a/v
We know that is goes against the spec but we need to support it as we have this workaround all over our products.
This results in an invalid path that AMF tries to resolve pointing to an unexisting exchange_modules folder inside one of the nested dependencies, for that we created a new resource loader that looks for the exchange_modules folder on the root of the fat api.