### PR TITLE
STUDIO-17316: Fix api_example project

### DIFF
--- a/api_example/exchange.json
+++ b/api_example/exchange.json
@@ -7,18 +7,18 @@
         {
             "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
             "assetId": "training-american-flight-data-type",
-            "version": "2.0.0-SNAPSHOT"
+            "version": "1.0.1"
         },
         {
             "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
             "assetId": "training-american-flights-example",
-            "version": "2.0.0-SNAPSHOT"
+            "version": "1.0.1"
         }
     ],
     "groupId": "e391ca1a-41ef-49a4-88b3-ae1106af1867",
     "backwardsCompatible": false,
     "assetId": "american-flights-api",
-    "version": "2.0.0-SNAPSHOT",
+    "version": "1.0.0",
     "apiVersion": "v1",
     "metadata": {
         "projectId": "3fe3ce56-46da-4a8a-a863-3f79341414af",


### PR DESCRIPTION
The project used to test the polyglot (api_example/exchange.json) has some references to non-existing APIs. Seems like the exchange.json file includes non-existing version of some dependencies that were changed as part of the polyglot version bumping.

Today both dependencies have 2.0.0-SNAPSHOT as version
```
"dependencies": [
        {
            "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
            "assetId": "training-american-flight-data-type",
            "version": "2.0.0-SNAPSHOT"
        },
        {
            "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
            "assetId": "training-american-flights-example",
            "version": "2.0.0-SNAPSHOT"
        }
    ],
```

when the american-flights-api123567.raml is using version 1.0.1 of both assets:

```
types:
  AmericanFlight: !include exchange_modules/68ef9520-24e9-4cf2-b2f5-620025690913/training-american-flight-data-type/1.0.1/AmericanFlightDataType.raml
...
          application/json:
            type: AmericanFlight[]
            examples: !include exchange_modules/68ef9520-24e9-4cf2-b2f5-620025690913/training-american-flights-example/1.0.1/
```
 
Even It's not necessary to change the version of the example to 2.0.0-SNAPSHOT like today, it could stay as 1.0.0

    "groupId": "e391ca1a-41ef-49a4-88b3-ae1106af1867",
    "backwardsCompatible": false,
    "assetId": "american-flights-api",
    "version": "2.0.0-SNAPSHOT",