### PR TITLE
STUDIO-17318: Rollback API versions used for tests since it's not necessary to update them

### DIFF
--- a/polyglot-exchange/src/main/resources/exchangejson.jsonschema
+++ b/polyglot-exchange/src/main/resources/exchangejson.jsonschema
@@ -88,7 +88,7 @@
       "title": "The Version Schema",
       "default": "",
       "examples": [
-        "2.0.0-SNAPSHOT"
+        "1.0.4"
       ],
       "pattern": "^(.*)$"
     },

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/exchange.json
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/exchange.json
@@ -7,17 +7,17 @@
     {
       "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
       "assetId": "training-american-flight-data-type",
-      "version": "2.0.0-SNAPSHOT"
+      "version": "1.0.1"
     },
     {
       "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
       "assetId": "training-american-flights-example",
-      "version": "2.0.0-SNAPSHOT"
+      "version": "1.0.1"
     }
   ],
   "groupId": "e391ca1a-41ef-49a4-88b3-ae1106af1867",
   "assetId": "american-flights-api",
-  "version": "2.0.0-SNAPSHOT",
+  "version": "1.0.0-SNAPSHOT",
   "apiVersion": "v1",
   "metadata": {
     "projectId": "3fe3ce56-46da-4a8a-a863-3f79341414af",

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
@@ -4,20 +4,20 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>e391ca1a-41ef-49a4-88b3-ae1106af1867</groupId>
     <artifactId>american-flights-api</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>American Flights API</name>
     <dependencies>
         <dependency>
             <groupId>68ef9520-24e9-4cf2-b2f5-620025690913</groupId>
             <artifactId>training-american-flight-data-type</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>1.0.1</version>
             <type>zip</type>
             <classifier>raml-fragment</classifier>
         </dependency>
         <dependency>
             <groupId>68ef9520-24e9-4cf2-b2f5-620025690913</groupId>
             <artifactId>training-american-flights-example</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>1.0.1</version>
             <type>zip</type>
             <classifier>raml-fragment</classifier>
         </dependency>


### PR DESCRIPTION
The api_project_maven_client project uses some exchange.json and pom.xml files as part of the tests. The idea of those tests is to compare the pom.xml content with the pom.xml generated by the polyglot from the exchange.json file.

It seems that every time the polyglot version has been changed, the version of the API projects used for tests has been changed even when that is not necessary.

In order to be more clear and to avoid unnecessary changes in future iterations, we should roll back the API projects and their dependencies versions to the original ones (1.0.0-SNAPSHOT for every API project and 1.0.1 for the dependencies).

Also, the exchangejson.jsonschema file that represents the schema for an exchange.json, contains an example of the property version that is not necessary to update every time the polyglot version is changed.