### PR TITLE
STUDIO-17329: Upgrade AMF dependency to 4.7.8-0

### DIFF
--- a/exchange_api_packager/pom.xml
+++ b/exchange_api_packager/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.github.amlorg</groupId>
             <artifactId>amf-client_2.12</artifactId>
-            <version>4.7.3-1</version>
+            <version>4.7.8-0</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
We are updating the AMF version used in the api_project_maven_client to keep parity with the APIkit Scaffolder (the APIkit Parser wrapper uses this AMF version) and with the API Editor, which will use it through ALS 4.1.1.