### PR TITLE
W-11069714: fix parse error when resolving transitive dependencies with Exchange modules.

### DIFF
--- a/api_example/.mvn/extensions.xml
+++ b/api_example/.mvn/extensions.xml
@@ -3,6 +3,6 @@
     <extension>
          <groupId>org.mule.maven.exchange</groupId>
          <artifactId>polyglot-exchange</artifactId>
-        <version>2.1.2-SNAPSHOT</version>
+        <version>2.1.2</version>
     </extension>
 </extensions>

--- a/exchange-model/pom.xml
+++ b/exchange-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>exchange_maven_client</artifactId>
         <groupId>org.mule.maven.exchange</groupId>
-        <version>2.1.2-SNAPSHOT</version>
+        <version>2.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/exchange_api_packager/pom.xml
+++ b/exchange_api_packager/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>exchange_maven_client</artifactId>
         <groupId>org.mule.maven.exchange</groupId>
-        <version>2.1.2-SNAPSHOT</version>
+        <version>2.1.2</version>
     </parent>
 
     <dependencies>

--- a/exchange_api_packager/src/main/java/org/mule/maven/exchange/ValidateApiMojo.java
+++ b/exchange_api_packager/src/main/java/org/mule/maven/exchange/ValidateApiMojo.java
@@ -61,9 +61,8 @@ public class ValidateApiMojo extends AbstractMojo {
                 final String mainFileURL = URLDecoder.decode(ramlFile.toURI().toString(), "UTF-8");
                 final AMFBaseUnitClient client;
                 final AMFParseResult parseResult;
-                final AMFConfiguration amfConfiguration = WebAPIConfiguration.WebAPI();
-
-                amfConfiguration.withResourceLoader(new ExchangeModulesResourceLoader(parent.getAbsolutePath().replace(File.separator, "/")));
+                final AMFConfiguration amfConfiguration = WebAPIConfiguration.WebAPI().withResourceLoader(new ExchangeModulesResourceLoader(parent.getAbsolutePath().replace(File.separator, "/")));
+                
                 client = amfConfiguration.baseUnitClient();
                 parseResult = client.parse(mainFileURL).get();
                 

--- a/polyglot-exchange/pom.xml
+++ b/polyglot-exchange/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.mule.maven.exchange</groupId>
         <artifactId>exchange_maven_client</artifactId>
-        <version>2.1.2-SNAPSHOT</version>
+        <version>2.1.2</version>
     </parent>
 
 

--- a/polyglot-exchange/src/main/java/org/mule/maven/exchange/ExchangeModelProcessor.java
+++ b/polyglot-exchange/src/main/java/org/mule/maven/exchange/ExchangeModelProcessor.java
@@ -46,7 +46,7 @@ public class ExchangeModelProcessor implements ModelProcessor {
     private static final String EXCHANGE_JSON = "exchange.json";
     private static final String TEMPORAL_EXCHANGE_XML = ".exchange.xml";
 
-    public static final String PACKAGER_VERSION = "2.1.2-SNAPSHOT";
+    public static final String PACKAGER_VERSION = "2.1.2";
 
     public static final String MAVEN_FACADE_SYSTEM_PROPERTY = "-Dexchange.maven.repository.url";
 

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/basic/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/basic/pom.xml
@@ -25,7 +25,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.1.2-SNAPSHOT</version>
+                <version>2.1.2</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/fragment/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/fragment/pom.xml
@@ -25,7 +25,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.1.2-SNAPSHOT</version>
+                <version>2.1.2</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.1.2-SNAPSHOT</version>
+                <version>2.1.2</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/groupId_from_apivcs/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/groupId_from_apivcs/pom.xml
@@ -25,7 +25,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.1.2-SNAPSHOT</version>
+                <version>2.1.2</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.mule.maven.exchange</groupId>
     <artifactId>exchange_maven_client</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>2.1.2</version>
 
     <name>exchange_maven_client</name>
     <description>This project contains the maven polyglot extension and the maven packager to build an API project using maven</description>


### PR DESCRIPTION
There was an error when configuring the AMFConfiguration object. The method `withResourceLoader()` is not part of a builder, but returns a new object. This caused the config used to parse to not contain the corresponding resource loader needed to resolve exchange_modules dependencies and parsing failed.