### PR TITLE
Set correct classifier for ruleset dependencies and bump version for next release

### DIFF
--- a/api_example/.mvn/extensions.xml
+++ b/api_example/.mvn/extensions.xml
@@ -3,6 +3,6 @@
     <extension>
          <groupId>org.mule.maven.exchange</groupId>
          <artifactId>polyglot-exchange</artifactId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </extension>
 </extensions>

--- a/api_example/exchange.json
+++ b/api_example/exchange.json
@@ -13,6 +13,12 @@
             "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
             "assetId": "training-american-flights-example",
             "version": "1.0.1"
+        },
+        {
+            "groupId" : "68ef9520-24e9-4cf2-b2f5-620025690913",
+            "assetId" : "anypoint-best-practices",
+            "version" : "1.2.0",
+            "scope" : "validation"
         }
     ],
     "groupId": "e391ca1a-41ef-49a4-88b3-ae1106af1867",

--- a/exchange-model/pom.xml
+++ b/exchange-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>exchange_maven_client</artifactId>
         <groupId>org.mule.maven.exchange</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/exchange_api_packager/pom.xml
+++ b/exchange_api_packager/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>exchange_maven_client</artifactId>
         <groupId>org.mule.maven.exchange</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
 
     <dependencies>

--- a/polyglot-exchange/pom.xml
+++ b/polyglot-exchange/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.mule.maven.exchange</groupId>
         <artifactId>exchange_maven_client</artifactId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
 
 

--- a/polyglot-exchange/src/main/java/org/mule/maven/exchange/ExchangeModelProcessor.java
+++ b/polyglot-exchange/src/main/java/org/mule/maven/exchange/ExchangeModelProcessor.java
@@ -38,6 +38,11 @@ public class ExchangeModelProcessor implements ModelProcessor {
 
     public static final String ORG_ID_KEY = "orgId";
     public static final String RAML_FRAGMENT = "raml-fragment";
+    public static final String LIGHT_RULESET = "light-ruleset";
+    public static final String VALIDATION_SCOPE = "validation";
+    public static final String SCOPE_ADDITIONAL_PROPERTY_KEY = "scope";
+
+
 
     private static Logger LOGGER = Logger.getLogger(ExchangeModelProcessor.class.getName());
 
@@ -303,7 +308,12 @@ public class ExchangeModelProcessor implements ModelProcessor {
         result.setArtifactId(dep.getAssetId());
         result.setGroupId(dep.getGroupId());
         result.setVersion(dep.getVersion());
-        result.setClassifier(RAML_FRAGMENT);
+        if (VALIDATION_SCOPE.equals(dep.getAdditionalProperties().get(SCOPE_ADDITIONAL_PROPERTY_KEY))) {
+        	result.setClassifier(LIGHT_RULESET);
+        }
+        else {
+        	result.setClassifier(RAML_FRAGMENT);
+        }
         result.setType("zip");
         return result;
     }

--- a/polyglot-exchange/src/main/java/org/mule/maven/exchange/ExchangeModelProcessor.java
+++ b/polyglot-exchange/src/main/java/org/mule/maven/exchange/ExchangeModelProcessor.java
@@ -49,7 +49,7 @@ public class ExchangeModelProcessor implements ModelProcessor {
     private static final String EXCHANGE_JSON = "exchange.json";
     private static final String TEMPORAL_EXCHANGE_XML = ".exchange.xml";
 
-    public static final String PACKAGER_VERSION = "2.2.0";
+    public static final String PACKAGER_VERSION = "2.2.1";
 
     public static final String MAVEN_FACADE_SYSTEM_PROPERTY = "-Dexchange.maven.repository.url";
 

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/basic/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/basic/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.2.0</version>
+                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/fragment/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/fragment/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.2.0</version>
+                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.2.0</version>
+                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/groupId_from_apivcs/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/groupId_from_apivcs/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.2.0</version>
+                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.mule.maven.exchange</groupId>
     <artifactId>exchange_maven_client</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
 
     <name>exchange_maven_client</name>
     <description>This project contains the maven polyglot extension and the maven packager to build an API project using maven</description>


### PR DESCRIPTION
Rulesets published to Exchange are validated and set the light-ruleset classifier, so we should use that for dependencies with the validation scope. This should fix building problems with ruleset dependencies.