### PR TITLE
W-14072666: add flag to avoid packaging hidden files

### DIFF
--- a/api_example/.mvn/extensions.xml
+++ b/api_example/.mvn/extensions.xml
@@ -3,6 +3,6 @@
     <extension>
          <groupId>org.mule.maven.exchange</groupId>
          <artifactId>polyglot-exchange</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </extension>
 </extensions>

--- a/exchange-model/pom.xml
+++ b/exchange-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>exchange_maven_client</artifactId>
         <groupId>org.mule.maven.exchange</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/exchange-model/src/main/java/org/mule/maven/exchange/utils/ApiProjectConstants.java
+++ b/exchange-model/src/main/java/org/mule/maven/exchange/utils/ApiProjectConstants.java
@@ -14,7 +14,7 @@ public class ApiProjectConstants {
 
     public static final String MAVEN_SKIP_REST_CONNECT = "exchange.maven.restConnect.skip";
     public static final String MAVEN_SKIP_VALIDATE_API = "exchange.maven.validateApi.skip";
-    public static final String MAVEN_EXCLUDE_FILES = "exchange.maven.files.excludeProblematic";
+    public static final String MAVEN_EXCLUDE_FILES = "exchange.maven.files.excludeHidden";
     public static final String REST_CONNECT_OUTPUTDIR = "rest_connect_workdir";
 
     public static File getFatApiDirectory(File buildDirectory) {

--- a/exchange-model/src/main/java/org/mule/maven/exchange/utils/ApiProjectConstants.java
+++ b/exchange-model/src/main/java/org/mule/maven/exchange/utils/ApiProjectConstants.java
@@ -14,7 +14,7 @@ public class ApiProjectConstants {
 
     public static final String MAVEN_SKIP_REST_CONNECT = "exchange.maven.restConnect.skip";
     public static final String MAVEN_SKIP_VALIDATE_API = "exchange.maven.validateApi.skip";
-    public static final String MAVEN_FILTER_HIDDEN = "exchange.maven.filterHidden";
+    public static final String MAVEN_EXCLUDE_FILES = "exchange.maven.files.excludeProblematic";
     public static final String REST_CONNECT_OUTPUTDIR = "rest_connect_workdir";
 
     public static File getFatApiDirectory(File buildDirectory) {

--- a/exchange-model/src/main/java/org/mule/maven/exchange/utils/ApiProjectConstants.java
+++ b/exchange-model/src/main/java/org/mule/maven/exchange/utils/ApiProjectConstants.java
@@ -14,6 +14,7 @@ public class ApiProjectConstants {
 
     public static final String MAVEN_SKIP_REST_CONNECT = "exchange.maven.restConnect.skip";
     public static final String MAVEN_SKIP_VALIDATE_API = "exchange.maven.validateApi.skip";
+    public static final String MAVEN_FILTER_HIDDEN = "exchange.maven.filterHidden";
     public static final String REST_CONNECT_OUTPUTDIR = "rest_connect_workdir";
 
     public static File getFatApiDirectory(File buildDirectory) {

--- a/exchange_api_packager/pom.xml
+++ b/exchange_api_packager/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>exchange_maven_client</artifactId>
         <groupId>org.mule.maven.exchange</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
 
     <dependencies>

--- a/exchange_api_packager/src/main/java/org/mule/maven/exchange/ExchangeApiPackagerMojo.java
+++ b/exchange_api_packager/src/main/java/org/mule/maven/exchange/ExchangeApiPackagerMojo.java
@@ -58,10 +58,10 @@ public class ExchangeApiPackagerMojo extends AbstractMojo {
     private String classifier;
 
     /**
-     * property to avoid packaging problematic (hidden) files
+     * property to avoid packaging hidden files
      */
     @Parameter(property = ApiProjectConstants.MAVEN_EXCLUDE_FILES, defaultValue = "false")
-    private boolean excludeProblematicFiles;
+    private boolean excludeHiddenFiles;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -99,7 +99,7 @@ public class ExchangeApiPackagerMojo extends AbstractMojo {
         try {
             try (FileOutputStream fileWriter = new FileOutputStream(zipFile);
                  ZipOutputStream zip = new ZipOutputStream(fileWriter)) {
-                addZipEntries(sourceDir, fileFilter, zip, null, excludeProblematicFiles);
+                addZipEntries(sourceDir, fileFilter, zip, null, excludeHiddenFiles);
             }
         } catch (IOException e) {
             throw new MojoExecutionException("Exception while generating zip file", e);
@@ -114,17 +114,17 @@ public class ExchangeApiPackagerMojo extends AbstractMojo {
         return classifier;
     }
 
-    private void addZipEntries(File sourceDir, FileFilter fileFilter, ZipOutputStream zip, String basePath, boolean excludeProblematicFiles) throws IOException {
+    private void addZipEntries(File sourceDir, FileFilter fileFilter, ZipOutputStream zip, String basePath, boolean excludeHiddenFiles) throws IOException {
         final File[] files = sourceDir.listFiles(fileFilter);
         if (files != null) {
             for (File file : files) {
-                if (excludeProblematicFiles && isProblematicFile(file.getName())) {
-                    getLog().debug(String.format("excluded problematic file: `%s` from zip", file.getName()));
+                if (excludeHiddenFiles && isHiddenFile(file.getName())) {
+                    getLog().debug(String.format("excluded hidden file: `%s` from zip", file.getName()));
                     continue; // avoid zipping hidden files
                 }
                 final String name = basePath != null ? basePath + "/" + file.getName() : file.getName();
                 if (file.isDirectory()) {
-                    addZipEntries(file, fileFilter, zip, name, excludeProblematicFiles);
+                    addZipEntries(file, fileFilter, zip, name, excludeHiddenFiles);
                 } else {
                     // hack due to apikits issues while reading exchange.json file.
                     file = tamperFileIfExchangeJson(file);
@@ -142,7 +142,7 @@ public class ExchangeApiPackagerMojo extends AbstractMojo {
         }
     }
 
-    private boolean isProblematicFile(String entryName) {
+    private boolean isHiddenFile(String entryName) {
         return entryName.startsWith(".");
     }
 

--- a/polyglot-exchange/pom.xml
+++ b/polyglot-exchange/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.mule.maven.exchange</groupId>
         <artifactId>exchange_maven_client</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
 
 
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/polyglot-exchange/src/main/java/org/mule/maven/exchange/ExchangeModelProcessor.java
+++ b/polyglot-exchange/src/main/java/org/mule/maven/exchange/ExchangeModelProcessor.java
@@ -51,7 +51,7 @@ public class ExchangeModelProcessor implements ModelProcessor {
     private static final String EXCHANGE_JSON = "exchange.json";
     private static final String TEMPORAL_EXCHANGE_XML = ".exchange.xml";
 
-    public static final String PACKAGER_VERSION = "2.4.0";
+    public static final String PACKAGER_VERSION = "2.5.0";
 
     public static final String MAVEN_FACADE_SYSTEM_PROPERTY = "-Dexchange.maven.repository.url";
 

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/basic/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/basic/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.4.0</version>
+                <version>2.5.0</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/fragment/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/fragment/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.4.0</version>
+                <version>2.5.0</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.4.0</version>
+                <version>2.5.0</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/groupId_from_apivcs/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/groupId_from_apivcs/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.4.0</version>
+                <version>2.5.0</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.mule.maven.exchange</groupId>
     <artifactId>exchange_maven_client</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
 
     <name>exchange_maven_client</name>
 


### PR DESCRIPTION
when trying to publish in ACB - Windows, an error is thrown when trying to unzip some metadata files (.vscode/settings.json).
this hidden files along with other zip files don't appear to be needed in the packaged asset, and just bulk up and cause trouble.
The change is under a property flag in case some issues appear and it needs to work as before