### PR TITLE
W-17152780 Add new useLightRulesets parameter to transform zip ruleset dependencies to zip light-rulesets

### DIFF
--- a/api_example/.mvn/extensions.xml
+++ b/api_example/.mvn/extensions.xml
@@ -3,6 +3,6 @@
     <extension>
          <groupId>org.mule.maven.exchange</groupId>
          <artifactId>polyglot-exchange</artifactId>
-        <version>2.5.1</version>
+        <version>2.5.2</version>
     </extension>
 </extensions>

--- a/exchange-model/pom.xml
+++ b/exchange-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>exchange_maven_client</artifactId>
         <groupId>org.mule.maven.exchange</groupId>
-        <version>2.5.1</version>
+        <version>2.5.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/exchange_api_packager/pom.xml
+++ b/exchange_api_packager/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>exchange_maven_client</artifactId>
         <groupId>org.mule.maven.exchange</groupId>
-        <version>2.5.1</version>
+        <version>2.5.2</version>
     </parent>
 
     <dependencies>

--- a/polyglot-exchange/pom.xml
+++ b/polyglot-exchange/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.mule.maven.exchange</groupId>
         <artifactId>exchange_maven_client</artifactId>
-        <version>2.5.1</version>
+        <version>2.5.2</version>
     </parent>
 
 

--- a/polyglot-exchange/src/test/java/org/mule/maven/exchange/model/processor/ExchangeModelProcessorTest.java
+++ b/polyglot-exchange/src/test/java/org/mule/maven/exchange/model/processor/ExchangeModelProcessorTest.java
@@ -43,6 +43,9 @@ public class ExchangeModelProcessorTest {
             if (!testCase.getName().startsWith("groupId")) {
                 System.setProperty("groupId", "org.mule.test");
             }
+            if (testCase.getName().equals("light_ruleset")) {
+                System.setProperty("exchange.maven.dependencies.useLightRulesets", "true");
+            }
             final ExchangeModelProcessor exchangeModelProcessor = new ExchangeModelProcessor();
             final HashMap<String, Object> options = new HashMap<>();
             final File exchangeFile = getExchangeFile(testCase);

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/basic/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/basic/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.5.1</version>
+                <version>2.5.2</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/fragment/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/fragment/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.5.1</version>
+                <version>2.5.2</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/full/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>org.mule.maven.exchange</groupId>
                 <artifactId>exchange_api_packager</artifactId>
-                <version>2.5.1</version>
+                <version>2.5.2</version>
                 <executions>
                     <execution>
                         <id>generate-full-api</id>

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/light_ruleset/exchange.json
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/light_ruleset/exchange.json
@@ -1,0 +1,46 @@
+{
+  "main": "american-flights-api123567.raml",
+  "name": "American Flights API",
+  "classifier": "raml",
+  "tags": [],
+  "dependencies": [
+    {
+      "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
+      "assetId": "training-american-flight-data-type",
+      "version": "1.0.1",
+      "classifier": "oas-components",
+      "packaging": "zip"
+    },
+    {
+      "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
+      "assetId": "training-american-flights-example",
+      "version": "1.0.1"
+    },
+    {
+      "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
+      "assetId": "test",
+      "version": "1.0.1",
+      "scope": "validation",
+      "classifier": "ruleset",
+      "packaging": "zip"
+    },
+    {
+      "groupId": "68ef9520-24e9-4cf2-b2f5-620025690913",
+      "assetId": "other-test",
+      "version": "1.0.1",
+      "scope": "validation",
+      "classifier": "ruleset",
+      "packaging": "yaml"
+    }
+  ],
+  "groupId": "e391ca1a-41ef-49a4-88b3-ae1106af1867",
+  "descriptorVersion": "1.0.0",
+  "assetId": "american-flights-api",
+  "version": "1.0.0-SNAPSHOT",
+  "apiVersion": "v1",
+  "metadata": {
+    "projectId": "3fe3ce56-46da-4a8a-a863-3f79341414af",
+    "branchId": "master",
+    "commitId": "970bccf0a9c0f0980864f3342e336f853a034964"
+  }
+}

--- a/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/light_ruleset/pom.xml
+++ b/polyglot-exchange/src/test/resources/org/mule/maven/exchange/model/processor/light_ruleset/pom.xml
@@ -1,11 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>2f45ba3e-06fc-4bb5-91f8-2e0a3a6f540f</groupId>
-    <artifactId>lautaro_raml</artifactId>
+    <groupId>e391ca1a-41ef-49a4-88b3-ae1106af1867</groupId>
+    <artifactId>american-flights-api</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <name>lautaro_raml</name>
+    <name>American Flights API</name>
+    <dependencies>
+        <dependency>
+            <groupId>68ef9520-24e9-4cf2-b2f5-620025690913</groupId>
+            <artifactId>training-american-flight-data-type</artifactId>
+            <version>1.0.1</version>
+            <type>zip</type>
+            <classifier>oas-components</classifier>
+        </dependency>
+        <dependency>
+            <groupId>68ef9520-24e9-4cf2-b2f5-620025690913</groupId>
+            <artifactId>training-american-flights-example</artifactId>
+            <version>1.0.1</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>68ef9520-24e9-4cf2-b2f5-620025690913</groupId>
+            <artifactId>test</artifactId>
+            <version>1.0.1</version>
+            <type>zip</type>
+            <classifier>light-ruleset</classifier>
+        </dependency>
+        <dependency>
+            <groupId>68ef9520-24e9-4cf2-b2f5-620025690913</groupId>
+            <artifactId>other-test</artifactId>
+            <version>1.0.1</version>
+            <type>yaml</type>
+            <classifier>ruleset</classifier>
+        </dependency>
+    </dependencies>
     <repositories>
         <repository>
             <id>anypoint-exchange-v3</id>
@@ -57,7 +86,7 @@
                 </executions>
                 <configuration>
                     <classifier>raml</classifier>
-                    <mainFile>lautaro_raml.raml</mainFile>
+                    <mainFile>american-flights-api123567.raml</mainFile>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.mule.maven.exchange</groupId>
     <artifactId>exchange_maven_client</artifactId>
     <packaging>pom</packaging>
-    <version>2.5.1</version>
+    <version>2.5.2</version>
 
     <name>exchange_maven_client</name>
 


### PR DESCRIPTION
W-17152780 Add new useLightRulesets parameter to transform zip ruleset dependencies to zip light-rulesets for compatibility with yaml uploaded rulesets.

Parameter: `exchange.maven.dependencies.useLightRulesets`

When publishing custom rulesets using YAML files instead of zip files, Exchange only exposes as available files to consume:
- ruleset classifier + yaml packaging
- light-ruleset classifier + zip packaging (generated)
- fat-ruleset classifier + zip packaging (generated)

When publishing custom rulesets using a ZIP file, Exchange exposes as available files to consume:
- ruleset classifier + yaml zip
- light-ruleset classifier + zip packaging (generated)
- fat-ruleset classifier + zip packaging (generated)

As a consequence, when trying to download classifier ruleset with packaging zip, resolution fails for those that were published using YAML files.

This fix adds a new parameter that enables transformation from ruleset classifier to light-ruleset to avoid compatibility issues when using YAML, since light-ruleset with zip packaging will always be present for all rulesets regardless of their original packaging (YAML or ZIP).